### PR TITLE
Reset game

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,6 +45,7 @@ button.addEventListener('click', displayChooseGameView);
 
 fighterContainer.addEventListener('click', function(event) { 
   playGame(game, event.target, user, computer);
+  setTimeout(reset, 1250, game);
 });
 
 // FUNCTIONS
@@ -188,6 +189,11 @@ function announceDraw() {
   result.innerText = `It's a draw!`;
 };
 
-function reset() {
+function reset(game) {
   fighterSection.innerHTML = '';
+  if (game.type = 'classic') {
+    displayClassicView();
+  } else {
+    displayVariationView();
+  }
 }


### PR DESCRIPTION
What I did:
Added reset function; automatically resets the page to the choose fighter view for the same game type as previously selected after waiting a short time, and wipes out fighter section HTML.

Did this break anything?
- [x] No
- [ ] Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)

Checklist:
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Refactor everything up to this point, then move on to variation planning.