### PR TITLE
Reset wins button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
           <!-- Num Player 1 Wins Goes Here -->
         </span>
       </h3>
-      <button class="classic-button hidden">Change Game?</button>
-      <button class="wizard-button hidden">Change Game?</button>
+      <button class="classic-button classic-game-button hidden">Change Game?</button>
+      <button class="wizard-button wizard-game-button hidden">Change Game?</button>
     </section>
     <main class="panel">
       <h1>Rock, Paper, Scissors</h1>
@@ -87,6 +87,8 @@
           <!-- Num Player 2 Wins Goes Here -->
         </span>
       </h3>
+      <button class="classic-button classic-reset-button hidden">Reset Wins?</button>
+      <button class="wizard-button wizard-reset-button hidden">Reset Wins?</button>
     </section>
   <script src="./main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -20,8 +20,8 @@ chooseGameView = document.querySelector('.choose-game-view');
 classicView = document.querySelector('.choose-fighter-classic');
 wizardView = document.querySelector('.choose-fighter-wizard');
 resultView = document.querySelector('.result-view');
-classicButton = document.querySelector('.classic-button');
-wizardButton = document.querySelector('.wizard-button');
+classicGameButton = document.querySelector('.classic-game-button');
+wizardGameButton = document.querySelector('.wizard-game-button');
 gameBoxesContainer = document.querySelector('.game-boxes-container');
 classicFighterContainer = document.querySelector('.classic-icons');
 wizardFighterContainer = document.querySelector('.wizard-icons')
@@ -33,9 +33,8 @@ player2Name = document.querySelector('.player2-name');
 player2Wins = document.querySelector('.player2-wins');
 result = document.querySelector('.result');
 fighterSection = document.querySelector('.fighters');
-rockImg = document.querySelector('.rock');
-paperImg = document.querySelector('.paper');
-scissorsImg = document.querySelector('.scissors');
+classicResetButton = document.querySelector('.classic-reset-button');
+wizardResetButton = document.querySelector('.wizard-reset-button');
 
 // EVENT LISTENERS
 window.addEventListener('load', function() {
@@ -55,9 +54,6 @@ gameBoxesContainer.addEventListener('click', function(event) {
   displayGame(game);
 });
 
-classicButton.addEventListener('click', displayChooseGameView);
-wizardButton.addEventListener('click', displayChooseGameView);
-
 classicFighterContainer.addEventListener('click', function(event) { 
   updateFighters(game, event.target);
 });
@@ -65,6 +61,17 @@ classicFighterContainer.addEventListener('click', function(event) {
 wizardFighterContainer.addEventListener('click', function(event) { 
   updateFighters(game, event.target);
 });
+
+classicResetButton.addEventListener('click', function() {
+  resetWins(user, computer);
+});
+
+wizardResetButton.addEventListener('click', function() {
+  resetWins(user, computer);
+});
+
+classicGameButton.addEventListener('click', displayChooseGameView);
+wizardGameButton.addEventListener('click', displayChooseGameView);
 
 // FUNCTIONS - DATA MODEL
 function createPlayer(name, token, wins = 0) {
@@ -136,6 +143,22 @@ function winFight(player) {
   return player;
 }
 
+function resetWins(player1, player2) {
+  player1.wins = 0;
+  player2.wins = 0;
+  displayWins(player1, player2);
+}
+
+function displayResetButton(player1, player2) {
+  if (player1.wins && player2.wins) {
+    show(classicResetButton);
+    show(wizardResetButton);
+  } else {
+    hide(classicResetButton);
+    hide(wizardResetButton);
+  }
+}
+
 // FUNCTIONS - DOM
 function show(element) {
   element.classList.remove('hidden');
@@ -168,8 +191,9 @@ function displayGame(game) {
 
 function displayClassicView() {
   show(classicView);
-  show(classicButton);
-  hide(wizardButton);
+  show(classicGameButton);
+  show(classicResetButton);
+  hide(wizardGameButton);
   hide(chooseGameView);
   hide(wizardView);
   hide(resultView);
@@ -177,8 +201,9 @@ function displayClassicView() {
 
 function displayVariationView() {
   show(wizardView);
-  show(wizardButton);
-  hide(classicButton);
+  show(wizardGameButton);
+  show(wizardResetButton);
+  hide(classicGameButton);
   hide(chooseGameView);
   hide(classicView);
   hide(resultView);
@@ -186,8 +211,10 @@ function displayVariationView() {
 
 function displayChooseGameView() {
   show(chooseGameView);
-  hide(classicButton);
-  hide(wizardButton);
+  hide(classicGameButton);
+  hide(wizardGameButton);
+  hide(classicResetButton);
+  hide(wizardResetButton);
   hide(classicView);
   hide(wizardView);
   hide(resultView);
@@ -198,13 +225,19 @@ function displayResult(game) {
   hide(chooseGameView);
   hide(classicView);
   hide(wizardView);
-  if (game.type === 'classic') {
-    show(classicButton);
-    hide(wizardButton);
-  } else {
-    show(wizardButton);
-    hide(classicButton);
-  }
+
+  // if (game.type === 'classic') {
+  //   show(classicGameButton);
+  //   show(classicResetButton);
+  //   hide(wizardGameButton);
+  //   hide(wizardResetButton);
+  // } else {
+  //   show(wizardGameButton);
+  //   show(wizardResetButton);
+  //   hide(classicGameButton);
+  //   hide(classicResetButton);
+  // };
+
   displayFighter(fighter1);
   displayFighter(fighter2); 
   setTimeout(reset, 1250, game);

--- a/styles.css
+++ b/styles.css
@@ -195,8 +195,6 @@ img {
   margin: 0;
 }
 
-
-
 /* HIDDEN */
 
 .hidden {


### PR DESCRIPTION
What I did:
- Added buttons to reset wins to 0 when clicked
- button only shows within games, not on choose-game-page
- 2 buttons; alternate showing/hidden depending on which game is chosen, to maintain game-theme styling
- renamed choose game buttons for clarity

Did this break anything?
- [x] No
- [ ] Yes

Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)

Checklist:
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Continue on enhance styling branch; plan additional features