### PR TITLE
fix: Hide buttons while result is shown

### DIFF
--- a/main.js
+++ b/main.js
@@ -246,6 +246,10 @@ function displayResult(game) {
   hide(classicView);
   hide(wizardView);
   hide(loginView);
+  hide(classicGameButton);
+  hide(wizardGameButton);
+  hide(classicResetButton);
+  hide(wizardResetButton);
   displayFighter(fighter1);
   displayFighter(fighter2); 
   setTimeout(reset, 1250, game);


### PR DESCRIPTION
What I did:
- Hid buttons when result view is shown so that user cannot click to another screen until timeout is complete

Did this break anything?
- [x] No
- [ ] Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Make design more responsive for mid-size screens. All current design was done on a 27" screen and text is too large on laptop.

